### PR TITLE
changed to EntityComponent instead of StartupScript

### DIFF
--- a/BepuPhysicIntegrationTest/Integration/Components/Colliders/_ColliderComponent.cs
+++ b/BepuPhysicIntegrationTest/Integration/Components/Colliders/_ColliderComponent.cs
@@ -10,16 +10,10 @@ namespace BepuPhysicIntegrationTest.Integration.Components.Colliders
     [DataContract]
     [DefaultEntityComponentProcessor(typeof(ColliderProcessor), ExecutionMode = ExecutionMode.Runtime)]
     [ComponentCategory("Bepu - Colliders")]
-    public abstract class ColliderComponent : StartupScript
+    public abstract class ColliderComponent : EntityComponent
     {
         public float Mass { get; set; } = 1f;
 
         internal ContainerComponent Container => Entity.GetInMeOrParents<ContainerComponent>();
-        
-        public override void Start()
-        {
-            base.Start();
-        }
-
     }
 }

--- a/BepuPhysicIntegrationTest/Integration/Components/Containers/_ContainerComponent.cs
+++ b/BepuPhysicIntegrationTest/Integration/Components/Containers/_ContainerComponent.cs
@@ -10,14 +10,9 @@ namespace BepuPhysicIntegrationTest.Integration.Components.Containers
     [DefaultEntityComponentProcessor(typeof(ContainerProcessor), ExecutionMode = ExecutionMode.Runtime)]
     [ComponentCategory("Bepu - Containers")]
 
-    public abstract class ContainerComponent : StartupScript
+    public abstract class ContainerComponent : EntityComponent
     {
         public SimulationComponent BepuSimulation => Entity.GetInMeOrParents<SimulationComponent>();
         internal ContainerData ContainerData { get; set; }
-
-        public override void Start()
-        {
-            base.Start();
-        }
     }
 }

--- a/BepuPhysicIntegrationTest/Integration/Components/Simulations/SimulationComponent.cs
+++ b/BepuPhysicIntegrationTest/Integration/Components/Simulations/SimulationComponent.cs
@@ -12,9 +12,10 @@ using Stride.Engine.Design;
 
 namespace BepuPhysicIntegrationTest.Integration.Components.Simulations
 {
+    [DataContract]
     [DefaultEntityComponentProcessor(typeof(SimulationProcessor), ExecutionMode = ExecutionMode.Runtime)]
     [ComponentCategory("Bepu - Simulations")]
-    public class SimulationComponent : StartupScript
+    public class SimulationComponent : EntityComponent
     {
         internal ThreadDispatcher ThreadDispatcher { get; }
         internal BufferPool BufferPool { get; }
@@ -40,13 +41,6 @@ namespace BepuPhysicIntegrationTest.Integration.Components.Simulations
         public int SolveIteration = 2; //4
         [Display(6, "SolveSubStep")]
         public int SolveSubStep = 4; //8
-
-
-        public override void Start()
-        {
-
-            base.Start();
-        }
 
         public SimulationComponent()
         {


### PR DESCRIPTION
StartupScript shouldnt be needed unless you require access to the Start method. With an EntityProcessor you can use the OnEntityComponentAdding instead like you already are.

This wont have an impact on the update AFAIK but should help with instantiation a small amount.